### PR TITLE
T23208: Add dependency on libgtest-dev and google-mock

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,11 @@ Build-Depends: debhelper (>= 8.0.0),
                cdbs,
                git,
                gobject-introspection,
+               googletest,
+               google-mock,
                libgirepository1.0-dev,
                libglib2.0-dev,
+               libgtest-dev,
                meson
 Standards-Version: 3.9.4
 Section: libs

--- a/debian/rules
+++ b/debian/rules
@@ -9,15 +9,3 @@
 %:
 	dh $@ --buildsystem=meson
 
-override_dh_auto_configure:
-	rm -rf obj-${DEB_HOST_MULTIARCH} && \
-	mkdir -p obj-${DEB_HOST_MULTIARCH} && \
-	cd obj-${DEB_HOST_MULTIARCH} && \
-	LC_ALL=C.UTF-8 meson \
-	 .. \
-	 --buildtype=plain \
-	 --prefix=/usr \
-	 --sysconfdir=/etc \
-	 --localstatedir=/var \
-	 --libdir=lib/${DEB_HOST_MULTIARCH} \
-	 --libexecdir=lib/${DEB_HOST_MULTIARCH}

--- a/matchers/meson.build
+++ b/matchers/meson.build
@@ -29,8 +29,8 @@ mathematical_model_matcher_lib = static_library(
   'mathematical_model_matcher',
   mathematical_model_matcher_sources,
   dependencies: [
-    gtest_project.get_variable('gtest_dep'),
-    gtest_project.get_variable('gmock_dep'),
+    gtest_dep,
+    gmock_dep,
     wobbly_dep
   ],
   install: false
@@ -50,8 +50,8 @@ within_geometry_matcher_lib = static_library(
   'within_geometry_matcher',
   within_geometry_matcher_sources,
   dependencies: [
-    gtest_project.get_variable('gtest_dep'),
-    gtest_project.get_variable('gmock_dep'),
+    gtest_dep,
+    gmock_dep,
     wobbly_dep
   ],
   install: false

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,16 @@ project('libwobbly', 'cpp',
         license: 'LGPL2+',
         meson_version: '>= 0.40.0')
 
-gtest_project = subproject('googletest')
+gtest_dep = dependency('gtest', required: false)
+gtest_main_dep = dependency('gtest', main: true, required: false)
+gmock_dep = dependency('gmock', required: false)
+
+if not gtest_dep.found() or not gtest_main_dep.found() or not gmock_dep.found()
+  gtest_project = subproject('googletest')
+  gtest_dep = gtest_project.get_variable('gtest_dep')
+  gtest_main_dep = gtest_project.get_variable('gtest_main_dep')
+  gmock_dep = gtest_project.get_variable('gmock_dep')
+endif
 
 wobbly_inc = include_directories('.')
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,9 +37,9 @@ wobbly_test_executable = executable(
   'windowfx_wobbly_test',
   wobbly_test_sources,
   dependencies: [
-    gtest_project.get_variable('gtest_main_dep'),
-    gtest_project.get_variable('gtest_dep'),
-    gtest_project.get_variable('gmock_dep'),
+    gtest_dep,
+    gtest_main_dep,
+    gmock_dep,
     glib,
     gobject,
     mathematical_model_matcher_dep,


### PR DESCRIPTION
This will allow us to use the distro version of the sources without having to rely on the subproject (which won't build on obs as downloading subproject sources requires a network connection).

https://phabricator.endlessm.com/T23208