### PR TITLE
fix glib module, introduced pointers in order to allow gjs object mapping

### DIFF
--- a/animation-glib/wobbly/anchor.cpp
+++ b/animation-glib/wobbly/anchor.cpp
@@ -51,13 +51,13 @@ G_DEFINE_TYPE_WITH_PRIVATE (AnimationWobblyAnchor,
  */
 void
 animation_wobbly_anchor_move_by (AnimationWobblyAnchor *anchor,
-                                 AnimationVector        vector)
+                                 AnimationVector       *vector)
 {
   AnimationWobblyAnchorPrivate *priv =
     reinterpret_cast <AnimationWobblyAnchorPrivate *> (animation_wobbly_anchor_get_instance_private (anchor));
 
   if (priv->anchor != nullptr)
-    priv->anchor->MoveBy (animation::Point (vector.x, vector.y));
+    priv->anchor->MoveBy (animation::Point (vector->x, vector->y));
 }
 
 

--- a/animation-glib/wobbly/anchor.h
+++ b/animation-glib/wobbly/anchor.h
@@ -36,7 +36,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (AnimationWobblyAnchor, animation_wobbly_anchor, ANIMATION, WOBBLY_ANCHOR, GObject)
 
 void animation_wobbly_anchor_move_by (AnimationWobblyAnchor *anchor,
-                                      AnimationVector        vector);
+                                      AnimationVector       *vector);
 
 void animation_wobbly_anchor_release (AnimationWobblyAnchor *anchor);
 

--- a/animation-glib/wobbly/model.cpp
+++ b/animation-glib/wobbly/model.cpp
@@ -81,12 +81,12 @@ namespace agd = animation::geometry::dimension;
  */
 AnimationWobblyAnchor *
 animation_wobbly_model_grab_anchor (AnimationWobblyModel *model,
-                                    AnimationVector       position)
+                                    AnimationVector      *position)
 {
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
-  wobbly::Anchor anchor (priv->model->GrabAnchor (animation::Point (position.x,
-                                                                    position.y)));
+  wobbly::Anchor anchor (priv->model->GrabAnchor (animation::Point (position->x,
+                                                                    position->y)));
 
   return animation_wobbly_anchor_new_for_native_anchor_rvalue (std::move (anchor));
 }
@@ -111,12 +111,12 @@ animation_wobbly_model_grab_anchor (AnimationWobblyModel *model,
  */
 AnimationWobblyAnchor *
 animation_wobbly_model_insert_anchor (AnimationWobblyModel *model,
-                                      AnimationVector       position)
+                                      AnimationVector      *position)
 {
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
-  wobbly::Anchor anchor (priv->model->InsertAnchor (animation::Point (position.x,
-                                                                      position.y)));
+  wobbly::Anchor anchor (priv->model->InsertAnchor (animation::Point (position->x,
+                                                                      position->y)));
 
   return animation_wobbly_anchor_new_for_native_anchor_rvalue (std::move (anchor));
 }
@@ -155,7 +155,7 @@ animation_wobbly_model_step (AnimationWobblyModel *model,
  */
 void
 animation_wobbly_model_deform_texcoords (AnimationWobblyModel *model,
-                                         AnimationVector       uv,
+                                         AnimationVector      *uv,
                                          AnimationVector      *deformed)
 {
   AnimationWobblyModelPrivate *priv =
@@ -163,7 +163,7 @@ animation_wobbly_model_deform_texcoords (AnimationWobblyModel *model,
 
   g_return_if_fail (deformed != NULL);
 
-  animation::Point deformed_point (priv->model->DeformTexcoords (animation::Point (uv.x, uv.y)));
+  animation::Point deformed_point (priv->model->DeformTexcoords (animation::Point (uv->x, uv->y)));
   *deformed = {
     animation::geometry::dimension::get <0> (deformed_point),
     animation::geometry::dimension::get <1> (deformed_point)
@@ -217,15 +217,15 @@ animation_wobbly_model_query_extremes (AnimationWobblyModel *model,
  */
 void
 animation_wobbly_model_move_to (AnimationWobblyModel *model,
-                                AnimationVector       position)
+                                AnimationVector      *position)
 {
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
 
-  priv->prop_position = position;
+  priv->prop_position = {position->x, position->y};
 
   if (priv->model != nullptr)
-    priv->model->MoveModelTo (animation::Point (position.x, position.y));
+    priv->model->MoveModelTo (animation::Point (position->x, position->y));
 }
 
 /**
@@ -237,16 +237,16 @@ animation_wobbly_model_move_to (AnimationWobblyModel *model,
  */
 void
 animation_wobbly_model_move_by (AnimationWobblyModel *model,
-                                AnimationVector       delta)
+                                AnimationVector      *delta)
 {
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
 
-  priv->prop_position.x += delta.x;
-  priv->prop_position.y += delta.y;
+  priv->prop_position.x += delta->x;
+  priv->prop_position.y += delta->y;
 
   if (priv->model != nullptr)
-    priv->model->MoveModelBy (animation::Point (delta.x, delta.y));
+    priv->model->MoveModelBy (animation::Point (delta->x, delta->y));
 }
 
 /**
@@ -258,15 +258,15 @@ animation_wobbly_model_move_by (AnimationWobblyModel *model,
  */
 void
 animation_wobbly_model_resize (AnimationWobblyModel *model,
-                               AnimationVector       size)
+                               AnimationVector      *size)
 {
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
 
-  priv->prop_size = size;
+  priv->prop_size = {size->x, size->y};  
 
   if (priv->model != nullptr)
-    priv->model->ResizeModel (size.x, size.y);
+    priv->model->ResizeModel (size->x, size->y);
 }
 
 void
@@ -319,10 +319,10 @@ animation_wobbly_model_set_property (GObject      *object,
       animation_wobbly_model_set_maximum_range (model, g_value_get_double (value));
       break;
     case PROP_POSITION:
-      animation_wobbly_model_move_to (model, *(reinterpret_cast <AnimationVector *> (g_value_get_boxed (value))));
+      animation_wobbly_model_move_to (model, (reinterpret_cast <AnimationVector *> (g_value_get_boxed (value))));
       break;
     case PROP_SIZE:
-      animation_wobbly_model_resize (model, *(reinterpret_cast <AnimationVector *> (g_value_get_boxed (value))));
+      animation_wobbly_model_resize (model, (reinterpret_cast <AnimationVector *> (g_value_get_boxed (value))));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -445,8 +445,8 @@ animation_wobbly_model_class_init (AnimationWobblyModelClass *klass)
 }
 
 AnimationWobblyModel *
-animation_wobbly_model_new (AnimationVector position,
-                            AnimationVector size,
+animation_wobbly_model_new (AnimationVector *position,
+                            AnimationVector *size,
                             double       spring_constant,
                             double       friction,
                             double       maximum_range)
@@ -455,7 +455,7 @@ animation_wobbly_model_new (AnimationVector position,
                                                "spring-k", spring_constant,
                                                "friction", friction,
                                                "movement-range", maximum_range,
-                                               "position", &position,
-                                               "size", &size,
+                                               "position", position,
+                                               "size", size,
                                                nullptr));
 }

--- a/animation-glib/wobbly/model.cpp
+++ b/animation-glib/wobbly/model.cpp
@@ -263,7 +263,7 @@ animation_wobbly_model_resize (AnimationWobblyModel *model,
   AnimationWobblyModelPrivate *priv =
     reinterpret_cast <AnimationWobblyModelPrivate *> (animation_wobbly_model_get_instance_private (model));
 
-  priv->prop_size = {size->x, size->y};  
+  priv->prop_size = {size->x, size->y};
 
   if (priv->model != nullptr)
     priv->model->ResizeModel (size->x, size->y);

--- a/animation-glib/wobbly/model.h
+++ b/animation-glib/wobbly/model.h
@@ -31,23 +31,23 @@ G_BEGIN_DECLS
 #define ANIMATION_WOBBLY_TYPE_MODEL animation_wobbly_model_get_type ()
 G_DECLARE_FINAL_TYPE (AnimationWobblyModel, animation_wobbly_model, ANIMATION, WOBBLY_MODEL, GObject)
 
-AnimationWobblyModel * animation_wobbly_model_new (AnimationVector  position,
-                                                   AnimationVector  size,
+AnimationWobblyModel * animation_wobbly_model_new (AnimationVector  *position,
+                                                   AnimationVector  *size,
                                                    double        spring_constant,
                                                    double        friction,
                                                    double        maximum_range);
 
 AnimationWobblyAnchor * animation_wobbly_model_grab_anchor (AnimationWobblyModel *model,
-                                                            AnimationVector position);
+                                                            AnimationVector *position);
 
 AnimationWobblyAnchor * animation_wobbly_model_insert_anchor (AnimationWobblyModel *model,
-                                                              AnimationVector position);
+                                                              AnimationVector *position);
 
 gboolean animation_wobbly_model_step (AnimationWobblyModel  *model,
                                       unsigned int  ms);
 
 void animation_wobbly_model_deform_texcoords (AnimationWobblyModel  *model,
-                                              AnimationVector  uv,
+                                              AnimationVector  *uv,
                                               AnimationVector *deformed);
 
 void animation_wobbly_model_query_extremes (AnimationWobblyModel  *model,
@@ -57,12 +57,12 @@ void animation_wobbly_model_query_extremes (AnimationWobblyModel  *model,
                                             AnimationVector *bottom_right);
 
 void animation_wobbly_model_move_to (AnimationWobblyModel *model,
-                                     AnimationVector position);
+                                     AnimationVector *position);
 void animation_wobbly_model_move_by (AnimationWobblyModel *model,
-                                     AnimationVector delta);
+                                     AnimationVector *delta);
 
 void animation_wobbly_model_resize (AnimationWobblyModel *model,
-                                    AnimationVector size);
+                                    AnimationVector *size);
 
 void animation_wobbly_model_set_spring_k (AnimationWobblyModel *model, double spring_constant);
 

--- a/tests/wobbly/glib_api_test.cpp
+++ b/tests/wobbly/glib_api_test.cpp
@@ -153,21 +153,20 @@ namespace
     TEST (WobblyGLibAPI, ConstructModel)
     {
 
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };
-    	
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
+
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-
     }
 
     TEST (WobblyGLibAPI, MoveModelChangesExtremes)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
@@ -176,8 +175,8 @@ namespace
 
         std::array <AnimationVector, 4> extremes;
 
-    	AnimationVector pos_to = { 1.0, 1.0 };
-    	
+        AnimationVector pos_to = { 1.0, 1.0 };
+
         animation_wobbly_model_move_to (model, &pos_to);
         animation_wobbly_model_query_extremes (model,
                                                &extremes[0],
@@ -200,13 +199,13 @@ namespace
                             return Eq (vector);
                         });
 
-        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges));
     }
 
     TEST (WobblyGLibAPI, ResizeModelChangesExtremes)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
@@ -215,7 +214,7 @@ namespace
 
         std::array <AnimationVector, 4> extremes;
 
-    	AnimationVector resize_dimensions = { 200.0, 200.0 };
+        AnimationVector resize_dimensions = { 200.0, 200.0 };
         animation_wobbly_model_resize (model, &resize_dimensions);
         animation_wobbly_model_query_extremes (model,
                                                &extremes[0],
@@ -238,23 +237,23 @@ namespace
                             return Eq (vector);
                         });
 
-        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges));
     }
 
     TEST (WobblyGLibAPI, GrabCorrectIndex)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-                                                                            
-    	AnimationVector grab_pos = { 100.0, 0.0 };                                                                            
+
+        AnimationVector grab_pos = { 100.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
 
-    	AnimationVector delta_pos = { 10.0, 10.0 };                                               
+        AnimationVector delta_pos = { 10.0, 10.0 };
         animation_wobbly_anchor_move_by (anchor, &delta_pos);
 
         AnimationVector topRightExtreme;
@@ -271,19 +270,19 @@ namespace
 
     TEST (WobblyGLibAPI, ModelSettlesAfterMovingAnchor)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-                                                                            
-    	AnimationVector grab_pos = { 100.0, 0.0 };
+
+        AnimationVector grab_pos = { 100.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
 
         // Move anchor and settle
-    	AnimationVector delta_pos = { 10.0, 10.0 };                                               
+        AnimationVector delta_pos = { 10.0, 10.0 };
         animation_wobbly_anchor_move_by (anchor, &delta_pos);
         while (animation_wobbly_model_step (model, 1));
 
@@ -309,28 +308,28 @@ namespace
                             return Eq (vector);
                         });
 
-        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges));
     }
 
     TEST (WobblyGLibAPI, DeformedWithGrabbedAnchor)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };    
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
 
-    	AnimationVector grab_pos = { 100.0, 0.0 };
+        AnimationVector grab_pos = { 100.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-    	AnimationVector delta_pos = { 10.0, 10.0 };
+        AnimationVector delta_pos = { 10.0, 10.0 };
         animation_wobbly_anchor_move_by (anchor, &delta_pos);
 
-    	AnimationVector texture_pos = { 0.5, 0.5 };
+        AnimationVector texture_pos = { 0.5, 0.5 };
         animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Not (Eq (center)));
@@ -338,23 +337,23 @@ namespace
 
     TEST (WobblyGLibAPI, DeformedWithInsertAnchor)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };        
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-    	AnimationVector insert_pos = { 70.0, 0.0 };
+        AnimationVector insert_pos = { 70.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_insert_anchor (model, &insert_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-    	AnimationVector delta_pos = { 10.0, 10.0 };
+        AnimationVector delta_pos = { 10.0, 10.0 };
         animation_wobbly_anchor_move_by (anchor, &delta_pos);
         animation_wobbly_model_step (model, 1);
 
-    	AnimationVector texture_pos = { 0.5, 0.5 };
+        AnimationVector texture_pos = { 0.5, 0.5 };
         animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Not (Eq (center)));
@@ -362,20 +361,20 @@ namespace
 
     TEST (WobblyGLibAPI, NoDeformationNoAnchorMove)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };        
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
                                                                             
-		AnimationVector grab_pos = { 100.0, 0.0 };
+        AnimationVector grab_pos = { 100.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-    	AnimationVector texture_pos = { 0.5, 0.5 };
+        AnimationVector texture_pos = { 0.5, 0.5 };
         animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Eq (center));
@@ -383,23 +382,23 @@ namespace
 
     TEST (WobblyGLibAPI, ReleaseAnchorOnModel)
     {
-    	AnimationVector pos = { 0.0, 0.0 };
-    	AnimationVector size = { 100.0, 100.0 };        
+        AnimationVector pos = { 0.0, 0.0 };
+        AnimationVector size = { 100.0, 100.0 };
         g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
                                                                             &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
 
-    	AnimationVector grab_pos = { 100.0, 0.0 };
+        AnimationVector grab_pos = { 100.0, 0.0 };
         g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
 
         // Temporarily grab another anchor and move the first one
         {
-    	AnimationVector grab_pos2 = { 0.0, 0.0 };        
+            AnimationVector grab_pos2 = { 0.0, 0.0 };
             g_autoptr(AnimationWobblyAnchor) otherAnchor = animation_wobbly_model_grab_anchor (model, &grab_pos2);
 
-	    	AnimationVector delta_pos = { 10.0, 10.0 };            
+            AnimationVector delta_pos = { 10.0, 10.0 };
             animation_wobbly_anchor_move_by (anchor, &delta_pos);
         }
 
@@ -431,6 +430,6 @@ namespace
                                                                                vector.y + 3.0)));
                         });
 
-        EXPECT_THAT (extremes, ElementsAreArray(textureEdges)); 
+        EXPECT_THAT (extremes, ElementsAreArray(textureEdges));
     }
 }

--- a/tests/wobbly/glib_api_test.cpp
+++ b/tests/wobbly/glib_api_test.cpp
@@ -152,24 +152,33 @@ namespace
 
     TEST (WobblyGLibAPI, ConstructModel)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };
+    	
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
+
     }
 
     TEST (WobblyGLibAPI, MoveModelChangesExtremes)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
 
         std::array <AnimationVector, 4> extremes;
 
-        animation_wobbly_model_move_to (model, { 1.0, 1.0 });
+    	AnimationVector pos_to = { 1.0, 1.0 };
+    	
+        animation_wobbly_model_move_to (model, &pos_to);
         animation_wobbly_model_query_extremes (model,
                                                &extremes[0],
                                                &extremes[1],
@@ -196,15 +205,18 @@ namespace
 
     TEST (WobblyGLibAPI, ResizeModelChangesExtremes)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
 
         std::array <AnimationVector, 4> extremes;
 
-        animation_wobbly_model_resize (model, { 200.0, 200.0 });
+    	AnimationVector resize_dimensions = { 200.0, 200.0 };
+        animation_wobbly_model_resize (model, &resize_dimensions);
         animation_wobbly_model_query_extremes (model,
                                                &extremes[0],
                                                &extremes[1],
@@ -231,14 +243,19 @@ namespace
 
     TEST (WobblyGLibAPI, GrabCorrectIndex)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+                                                                            
+    	AnimationVector grab_pos = { 100.0, 0.0 };                                                                            
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
 
-        animation_wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+    	AnimationVector delta_pos = { 10.0, 10.0 };                                               
+        animation_wobbly_anchor_move_by (anchor, &delta_pos);
 
         AnimationVector topRightExtreme;
         AnimationVector expectedTopRightExtreme = { 110.0, 0.0 };
@@ -254,15 +271,20 @@ namespace
 
     TEST (WobblyGLibAPI, ModelSettlesAfterMovingAnchor)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+                                                                            
+    	AnimationVector grab_pos = { 100.0, 0.0 };
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
 
-        /* Move anchor and settle */
-        animation_wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+        // Move anchor and settle
+    	AnimationVector delta_pos = { 10.0, 10.0 };                                               
+        animation_wobbly_anchor_move_by (anchor, &delta_pos);
         while (animation_wobbly_model_step (model, 1));
 
         std::array <AnimationVector, 4> extremes;
@@ -292,71 +314,96 @@ namespace
 
     TEST (WobblyGLibAPI, DeformedWithGrabbedAnchor)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };    
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+
+    	AnimationVector grab_pos = { 100.0, 0.0 };
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-        animation_wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
-        animation_wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+    	AnimationVector delta_pos = { 10.0, 10.0 };
+        animation_wobbly_anchor_move_by (anchor, &delta_pos);
+
+    	AnimationVector texture_pos = { 0.5, 0.5 };
+        animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Not (Eq (center)));
     }
 
     TEST (WobblyGLibAPI, DeformedWithInsertAnchor)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };        
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_insert_anchor (model, { 70.0, 0.0 });
+    	AnimationVector insert_pos = { 70.0, 0.0 };
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_insert_anchor (model, &insert_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-        animation_wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+    	AnimationVector delta_pos = { 10.0, 10.0 };
+        animation_wobbly_anchor_move_by (anchor, &delta_pos);
         animation_wobbly_model_step (model, 1);
-        animation_wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+
+    	AnimationVector texture_pos = { 0.5, 0.5 };
+        animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Not (Eq (center)));
     }
 
     TEST (WobblyGLibAPI, NoDeformationNoAnchorMove)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };        
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, { 100.0, 0.0 });
+                                                                            
+		AnimationVector grab_pos = { 100.0, 0.0 };
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
         AnimationVector deformed;
         AnimationVector center = { 50.0, 50.0 };
 
-        animation_wobbly_model_deform_texcoords (model, { 0.5, 0.5 }, &deformed);
+    	AnimationVector texture_pos = { 0.5, 0.5 };
+        animation_wobbly_model_deform_texcoords (model, &texture_pos, &deformed);
 
         EXPECT_THAT (deformed, Eq (center));
     }
 
     TEST (WobblyGLibAPI, ReleaseAnchorOnModel)
     {
-        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new ({ 0.0, 0.0 },
-                                                                            { 100.0, 100.0 },
+    	AnimationVector pos = { 0.0, 0.0 };
+    	AnimationVector size = { 100.0, 100.0 };        
+        g_autoptr(AnimationWobblyModel) model = animation_wobbly_model_new (&pos,
+                                                                            &size,
                                                                             8.0,
                                                                             5.0,
                                                                             500.0);
-        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, { 100.0, 0.0 });
 
-        /* Temporarily grab another anchor and move the first one */
+    	AnimationVector grab_pos = { 100.0, 0.0 };
+        g_autoptr(AnimationWobblyAnchor) anchor = animation_wobbly_model_grab_anchor (model, &grab_pos);
+
+        // Temporarily grab another anchor and move the first one
         {
-            g_autoptr(AnimationWobblyAnchor) otherAnchor = animation_wobbly_model_grab_anchor (model, { 0.0, 0.0 });
-            animation_wobbly_anchor_move_by (anchor, { 10.0, 10.0 });
+    	AnimationVector grab_pos2 = { 0.0, 0.0 };        
+            g_autoptr(AnimationWobblyAnchor) otherAnchor = animation_wobbly_model_grab_anchor (model, &grab_pos2);
+
+	    	AnimationVector delta_pos = { 10.0, 10.0 };            
+            animation_wobbly_anchor_move_by (anchor, &delta_pos);
         }
 
-        /* Anchor is now released. Settle model */
+        // Anchor is now released. Settle model
         while (animation_wobbly_model_step (model, 1));
 
         std::array <AnimationVector, 4> extremes;


### PR DESCRIPTION
In order to use the library within gnome shell extensions, the parameters must be pointers

https://phabricator.endlessm.com/T30439